### PR TITLE
[FEAT/#69] 멤버들의 아바타 정보 호출 타이밍 변경

### DIFF
--- a/iOS/Modak/Modak/App/ModakApp.swift
+++ b/iOS/Modak/Modak/App/ModakApp.swift
@@ -13,6 +13,7 @@ struct ModakApp: App {
     @StateObject private var logPileViewModel: LogPileViewModel
     = LogPileViewModel()
     @StateObject private var selectMergeLogsViewModel: SelectMergeLogsViewModel = SelectMergeLogsViewModel()
+    @StateObject private var avatarViewModel: AvatarViewModel = AvatarViewModel()
     
     init() {
         FirebaseApp.configure()
@@ -26,6 +27,7 @@ struct ModakApp: App {
                 .modelContainer(for: [PrivateLog.self, PrivateLogImage.self, Campfire.self])
                 .environmentObject(logPileViewModel)
                 .environmentObject(selectMergeLogsViewModel)
+                .environmentObject(avatarViewModel)
         }
     }
 }

--- a/iOS/Modak/Modak/View/Tab/Campfire/CampfireMainAvatarView.swift
+++ b/iOS/Modak/Modak/View/Tab/Campfire/CampfireMainAvatarView.swift
@@ -18,48 +18,11 @@ struct CampfireMainAvatarView: View {
             // scene 추가
             CustomSCNView(scene: avatarViewModel.scene)
                 .edgesIgnoringSafeArea(.all)
-                .onAppear {
-                    Task {
-                        guard let memberIds = viewModel.campfire?.memberIds else { return }
-                        await fetchMemberAvatars(memberIds: memberIds)
-                    }
-                }
-                .onChange(of: viewModel.campfire) { _, newValue in
-                    Task {
-                        guard let memberIds = viewModel.campfire?.memberIds else { return }
-                        await fetchMemberAvatars(memberIds: memberIds)
-                    }
-                }
                 .frame(height: 480)
             
             LottieView(filename: "fireTest")
                 .frame(width: 500, height: 500)
                 .padding(.top, 160)
-        }
-    }
-    
-    private func fetchMemberAvatars(memberIds: [Int]) async {
-        Task {
-            do {
-                let data = try await NetworkManager.shared.requestRawData(router: .getMembersNicknameAvatar(memberIds: memberIds))
-                let decoder = JSONDecoder()
-                if let jsonResponse = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let resultArray = jsonResponse["result"] as? [[String: Any]] {
-                    let jsonData = try JSONSerialization.data(withJSONObject: resultArray, options: [])
-                    let fetchedAvatars = try decoder.decode([MemberAvatar].self, from: jsonData)
-                    
-                    DispatchQueue.main.async {
-                        self.avatarViewModel.memberAvatars = fetchedAvatars
-                        print(">>> fetchedAvatars :\(fetchedAvatars)")
-                        avatarViewModel.avatar = AvatarData.sample2
-                        avatarViewModel.setupScene2()
-                    }
-                } else {
-                    print("Unexpected API response structure.")
-                }
-            } catch {
-                print("Error fetching member avatars: \(error)")
-            }
         }
     }
 }

--- a/iOS/Modak/Modak/View/Tab/Campfire/CampfireView.swift
+++ b/iOS/Modak/Modak/View/Tab/Campfire/CampfireView.swift
@@ -10,15 +10,28 @@ import SwiftData
 
 struct CampfireView: View {
     @EnvironmentObject private var viewModel: CampfireViewModel
+    @EnvironmentObject private var avatarViewModel: AvatarViewModel
     @Query var campfires: [Campfire]
     @Binding private(set) var isShowSideMenu: Bool
     
-    var body: some View {
+    var body: some View { 
         ZStack {
             if viewModel.isEmptyCampfire && campfires.isEmpty {
                 EmptyCampfireView()
             } else {
                 SelectedCampfireView(isShowSideMenu: $isShowSideMenu)
+            }
+        }
+        .onAppear {
+            Task {
+                guard let memberIds = viewModel.campfire?.memberIds else { return }
+                await avatarViewModel.fetchMemberAvatars(memberIds: memberIds)
+            }
+        }
+        .onChange(of: viewModel.campfire) { _, newValue in
+            Task {
+                guard let memberIds = viewModel.campfire?.memberIds else { return }
+                await avatarViewModel.fetchMemberAvatars(memberIds: memberIds)
             }
         }
         .background {


### PR DESCRIPTION
<!-- 제목 예시 -->
<!-- [FEAT/#6] 설명 -->
## 📝 작업 내용

-  멤버들의 아바타 정보 호출 타이밍 변경
- 누락된 ModakApp 코드 보냄

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
### 설명

selectedCampfireView에 campfireLog가 없으면 campfireMainAvatarView가 호출되지 않습니다. 그래서 그 안에있는, 멤버들의 아바타 정보를 불러오는 함수도 호출되지 않는다는.. 실수를 발견했습니다. 여기서 호출이 안되면, CampfireMemberDetailView에서 멤버들의 아바타를 표현할 수 없습니다. 그래서 호출 타이밍을 변경하였습니다. campfireLog의 유무와 상관없이 호출됩니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성하거나 커멘트로 남겨주세요
 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
